### PR TITLE
Criar classe BaseEntity e Enum de PersonType

### DIFF
--- a/Asaas/src/integration-test/main/groovy/asaas/enum/PersonType.groovy
+++ b/Asaas/src/integration-test/main/groovy/asaas/enum/PersonType.groovy
@@ -1,0 +1,20 @@
+package asaas
+import grails.util.Holders
+
+enum PersonType {
+   NATURAL,
+   LEGAL
+
+   public static PersonType convert(String personType) {
+       try {
+           if (personType instanceof String) personType = personType.toUpperCase()
+           return personType as PersonType
+       } catch(Exception e) {
+           return null
+       }
+   }
+
+   public String getLabel() {
+        return Holders.applicationContext.getBean("messageSource").getMessage("PersonType.${this}.label", null, "", new Locale("pt", "BR"))
+    }
+}

--- a/Asaas/src/integration-test/main/groovy/asaas/utils/BaseEntity.groovy
+++ b/Asaas/src/integration-test/main/groovy/asaas/utils/BaseEntity.groovy
@@ -1,0 +1,17 @@
+package asaas.utils
+
+abstract class BaseEntity {
+   Date dateCreated
+   Date lastUpdated
+   Boolean deleted = false
+
+  static constraints = {
+        dateCreated nullable: false
+        lastUpdated nullable: false
+        deleted nullable: false
+    }
+
+    static mapping = {
+        tablePerHierarchy false
+    }   
+}


### PR DESCRIPTION
Adicionando a classe BaseEntity que servirar como base para as entidades de dominio da aplicação. Além disso, foi feita a criação de Enum chamado PersonType que vai dizer se um customer é uma pessoa física ou jurídica. 

Link da tarefa do Jira: https://asaas-team-ytm2rk8u.atlassian.net/jira/software/projects/KAN/boards/1?selectedIssue=KAN-12
https://asaas-team-ytm2rk8u.atlassian.net/jira/software/projects/KAN/boards/1?selectedIssue=KAN-6